### PR TITLE
Fix login error test credentials

### DIFF
--- a/src/facades/tests/1_login.spec.ts
+++ b/src/facades/tests/1_login.spec.ts
@@ -22,7 +22,7 @@ test.describe('Login Page', () => {
 
     test('User login with incorrect credentials shows error', async ({ page }) => {
          const app = new AppFacade(page);
-        await app.loginAsUser("wrong_usernam", "wrond_password");
+        await app.loginAsUser('wrong_username', 'wrong_password');
         await expect(await app.getLoginErrorMessage()).toBe(LOGIN_ERROR);
         await expect(page).toHaveURL(BASE_URL);
     });


### PR DESCRIPTION
## Summary
- correct typo in wrong credentials login test

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf207f0d08332b2e59e68cab3ba38